### PR TITLE
Add OpenFunction go116 builder

### DIFF
--- a/builders/go115/README.md
+++ b/builders/go115/README.md
@@ -1,6 +1,6 @@
-## Build builder of go version 1.15
+# Build builder of go version 1.15
 
-### Build go115 stack
+## Build go115 stack
 
 ```shell
 bazel run //builders/go115/stack:build
@@ -13,7 +13,7 @@ openfunctiondev/buildpacks-go115-run:v1
 openfunctiondev/buildpacks-go115-build:v1
 ```
 
-### Build go115 builder
+## Build go115 builder
 
 ```shell
 bazel build //builders/go115:builder.image
@@ -32,13 +32,14 @@ docker tag of/go115 <your container registry>/go115:v1
 docker push <your container registry>/go115:v1
 ```
 
-### Test
+## Test
 
 ```shell
 bazel test //builders/go115/acceptance/...
 ```
 
-Output example:
+<details>
+<summary>Output example</summary>
 
 ```shell
 INFO: Analyzed 2 targets (0 packages loaded, 0 targets configured).
@@ -52,9 +53,14 @@ Executed 1 out of 1 test: 1 test passes.
 INFO: Build completed successfully, 7 total actions
 ```
 
-### Run locally
+</details>
 
-#### OpenFunction Samples:
+## Run locally
+
+<details>
+<summary>OpenFunction Samples</summary>
+
+---
 
 Download samples:
 
@@ -84,7 +90,12 @@ Output example:
 hello, world!
 ```
 
-#### GoogleCloudPlatform Samples
+</details>
+
+<details>
+<summary>GoogleCloudPlatform Samples</summary>
+
+---
 
 Download samples:
 
@@ -114,7 +125,9 @@ Output example:
 hello, world
 ```
 
-### Run on OpenFunction
+</details>
+
+## Run on OpenFunction
 
 1. [Install OpenFunction](https://github.com/OpenFunction/OpenFunction#quickstart)
 2. [Run a function](https://github.com/OpenFunction/OpenFunction#sample-run-a-function)

--- a/builders/go116/BUILD.bazel
+++ b/builders/go116/BUILD.bazel
@@ -12,7 +12,7 @@ builder(
         "go": [
             "//cmd/go/build:build.tgz",
             "//cmd/go/clear_source:clear_source.tgz",
-            "//cmd/go/functions_framework:functions_framework.tgz",
+            "//cmd/go/of_functions_framework:of_functions_framework.tgz",
         ],
     },
     image = "of/go116",

--- a/builders/go116/README.md
+++ b/builders/go116/README.md
@@ -1,6 +1,6 @@
-## Build builder of go version 1.15
+# Build builder of go version 1.15
 
-### Build go116 stack
+## Build go116 stack
 
 ```shell
 bazel run //builders/go116/stack:build
@@ -13,7 +13,7 @@ openfunctiondev/buildpacks-go116-run:v1
 openfunctiondev/buildpacks-go116-build:v1
 ```
 
-### Build go116 builder
+## Build go116 builder
 
 ```shell
 bazel build //builders/go116:builder.image
@@ -32,29 +32,73 @@ docker tag of/go116 <your container registry>/go116:v1
 docker push <your container registry>/go116:v1
 ```
 
-### Test
+## Test
 
 ```shell
 bazel test //builders/go116/acceptance/...
 ```
 
+<details>
+<summary>Output example</summary>
+
+```shell
+INFO: Analyzed 2 targets (8 packages loaded, 205 targets configured).
+INFO: Found 1 target and 1 test target...
+INFO: Elapsed time: 50.633s, Critical Path: 49.87s
+INFO: 10 processes: 3 internal, 6 linux-sandbox, 1 local.
+INFO: Build completed successfully, 10 total actions
+//builders/go116/acceptance:go_fn_test                                   PASSED in 48.1s
+
+Executed 1 out of 1 test: 1 test passes.
+INFO: Build completed successfully, 10 total actions
+```
+
+</details>
+
+## Run locally
+
+<details>
+<summary>OpenFunction Samples</summary>
+
+---
+
+Download samples:
+
+```shell
+git clone https://github.com/OpenFunction/function-samples.git
+```
+
+Build the function:
+
+> Add `--network host` to pack and docker command if they cannot reach internet.
+
+```shell
+cd function-samples/hello-world-go/
+pack build function-go --builder of/go116 --env FUNC_NAME="HelloWorld"
+docker run --rm -p8080:8080 function-go
+```
+
+Visit the function:
+
+```shell
+curl http://localhost:8080
+```
+
 Output example:
 
 ```shell
-INFO: Analyzed 2 targets (0 packages loaded, 0 targets configured).
-INFO: Found 1 target and 1 test target...
-INFO: Elapsed time: 36.640s, Critical Path: 36.47s
-INFO: 7 processes: 1 internal, 5 linux-sandbox, 1 local.
-INFO: Build completed successfully, 7 total actions
-//builders/go116/acceptance:go_fn_test                                   PASSED in 35.4s
-
-Executed 1 out of 1 test: 1 test passes.
-INFO: Build completed successfully, 7 total actions
+hello, world!
 ```
 
-### Run
+</details>
 
-Download gcp samples:
+<details>
+
+<summary>GoogleCloudPlatform Samples</summary>
+
+---
+
+Download samples:
 
 ```shell
 git clone https://github.com/GoogleCloudPlatform/buildpack-samples.git
@@ -82,7 +126,9 @@ Output example:
 hello, world
 ```
 
-### Run on OpenFunction
+</details>
+
+## Run on OpenFunction
 
 1. [Install OpenFunction](https://github.com/OpenFunction/OpenFunction#quickstart)
 2. [Run a function](https://github.com/OpenFunction/OpenFunction#sample-run-a-function)

--- a/builders/go116/acceptance/acceptance.go
+++ b/builders/go116/acceptance/acceptance.go
@@ -19,5 +19,5 @@ const (
 	// Buildpack identifiers used to verify that buildpacks were or were not used.
 	entrypoint      = "google.config.entrypoint"
 	goBuild         = "google.go.build"
-	goFF            = "google.go.functions-framework"
+	goFF            = "openfunction.go.of-functions-framework"
 )

--- a/builders/go116/acceptance/go_fn_test.go
+++ b/builders/go116/acceptance/go_fn_test.go
@@ -30,6 +30,14 @@ func TestAcceptanceGoFn(t *testing.T) {
 	testCases := []acceptance.Test{
 		{
 			Name:       "function with framework",
+			App:        "with_framework",
+			Path:       "/Func",
+			Env:        []string{"FUNC_NAME=Func"},
+			MustUse:    []string{goFF, goBuild},
+			MustNotUse: []string{entrypoint},
+		},
+		{
+			Name:       "function with framework go sum",
 			App:        "with_framework_go_sum",
 			Path:       "/Func",
 			Env:        []string{"FUNC_NAME=Func"},

--- a/builders/go116/builder.toml
+++ b/builders/go116/builder.toml
@@ -5,8 +5,8 @@ description = "Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js,
   uri = "entrypoint.tgz"
 
 [[buildpacks]]
-  id = "google.go.functions-framework"
-  uri = "go/functions_framework.tgz"
+  id = "openfunction.go.of-functions-framework"
+  uri = "go/of_functions_framework.tgz"
 
 [[buildpacks]]
   id = "google.go.clear_source"
@@ -27,7 +27,7 @@ description = "Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js,
 [[order]]
 
   [[order.group]]
-    id = "google.go.functions-framework"
+    id = "openfunction.go.of-functions-framework"
 
   [[order.group]]
     id = "google.go.build"
@@ -46,7 +46,7 @@ description = "Ubuntu 18 base image with buildpacks for .NET, Go, Java, Node.js,
 
 # Currently built with //builders/go116/stack/stack:build.
 [stack]
-  id = "google"
+  id = "openfunction.go116"
   build-image = "openfunctiondev/buildpacks-go116-build:v1"
   run-image = "openfunctiondev/buildpacks-go116-run:v1"
 

--- a/builders/go116/stack/parent.Dockerfile
+++ b/builders/go116/stack/parent.Dockerfile
@@ -16,7 +16,7 @@ FROM gcr.io/gcp-runtimes/ubuntu_18_0_4
 
 ARG cnb_uid=1000
 ARG cnb_gid=1000
-ARG stack_id="google"
+ARG stack_id="openfunction.go116"
 
 # Required by python/runtime: libexpat1, libffi6, libmpdecc2.
 # Required by dotnet/runtime: libicu60

--- a/cmd/config/entrypoint/buildpack.toml
+++ b/cmd/config/entrypoint/buildpack.toml
@@ -10,3 +10,6 @@ id = "google"
 
 [[stacks]]
 id = "openfunction.go115"
+
+[[stacks]]
+id = "openfunction.go116"

--- a/cmd/go/build/buildpack.toml
+++ b/cmd/go/build/buildpack.toml
@@ -10,3 +10,6 @@ id = "google"
 
 [[stacks]]
 id = "openfunction.go115"
+
+[[stacks]]
+id = "openfunction.go116"

--- a/cmd/go/clear_source/buildpack.toml
+++ b/cmd/go/clear_source/buildpack.toml
@@ -10,3 +10,6 @@ id = "google"
 
 [[stacks]]
 id = "openfunction.go115"
+
+[[stacks]]
+id = "openfunction.go116"

--- a/cmd/go/of_functions_framework/buildpack.toml
+++ b/cmd/go/of_functions_framework/buildpack.toml
@@ -10,3 +10,6 @@ id = "google"
 
 [[stacks]]
 id = "openfunction.go115"
+
+[[stacks]]
+id = "openfunction.go116"

--- a/cmd/utils/label/buildpack.toml
+++ b/cmd/utils/label/buildpack.toml
@@ -15,6 +15,9 @@ id = "google.dotnet3"
 id = "openfunction.go115"
 
 [[stacks]]
+id = "openfunction.go116"
+
+[[stacks]]
 id = "google.java11"
 
 [[stacks]]


### PR DESCRIPTION
This PR will add a builder for building go function of version 1.16.

It can detect and register the following types of functions to OpenFunction:

1. HTTP functions, with the following specifications.
    ```go
    func Function(w http.ResponseWriter, r *http.Request) {}
    ```
2. CloudEvent functions, with the following specifications.
    ```go
    func Function(ctx context.Context, event cloudevents.Event) error {}
    ```
3. OpenFunction Context functions, with the following specifications.
    ```go
    func Function(ctx *functionframeworks.OpenFunctionContext, r *http.Request) int {}
    ```

Already tested.

Signed-off-by: laminar <fangtian@yunify.com>