### PR TITLE
Add a ruby stack image for ruby builder

### DIFF
--- a/builders/ruby26/stack/BUILD.bazel
+++ b/builders/ruby26/stack/BUILD.bazel
@@ -1,0 +1,16 @@
+licenses(["notice"])
+
+sh_binary(
+    name = "build",
+    srcs = ["build.sh"],
+    args = [
+        "$(location build.sh)",
+        "$(location //licenses:licenses.tar)",
+    ],
+    data = [
+        "build.Dockerfile",
+        "parent.Dockerfile",
+        "run.Dockerfile",
+        "//licenses:licenses.tar",
+    ],
+)

--- a/builders/ruby26/stack/build.Dockerfile
+++ b/builders/ruby26/stack/build.Dockerfile
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG from_image
+FROM ${from_image}
+COPY licenses/ /usr/local/share/licenses/buildpacks/
+
+# build-essential is required by many usecases.
+# git is required for some project dependencies.
+# python3 is required by node-gyp to compile native modules.
+# unzip is required to extract gradle.
+# xz-utils is required to install nodejs/runtime.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
+  git \
+  python3 \
+  tar \
+  zip \
+  unzip \
+  xz-utils \
+  g++-8 \
+  gcc-8 \
+  zlib1g-dev \
+  libstdc++-8-dev \
+  pkg-config \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+USER cnb

--- a/builders/ruby26/stack/build.sh
+++ b/builders/ruby26/stack/build.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The build.sh script builds stack images for the gcp/base builder.
+#
+# The script builds the following two images:
+#   gcr.io/buildpacks/gcp/run:$tag
+#   gcr.io/buildpacks/gcp/build:$tag
+#
+# It also validates that the build image includes all required licenses.
+#
+# Usage:
+#   ./build.sh <path to self> <path to licenses.tar>
+
+set -euo pipefail
+
+# Convenient way to find the runfiles directory containing the Dockerfiles.
+# $0 is in a different directory top-level directory.
+DIR="$(dirname "$1")"
+LICENSES="$2"
+
+TAG="v1"
+
+# Extract licenses.tar because it is symlinked, which Docker does not support.
+readonly TEMP="$(mktemp -d)"
+trap "rm -rf $TEMP" EXIT
+
+echo "> Extracting licenses tar"
+mkdir -p "$TEMP/licenses"
+tar xf "$LICENSES" -C "$TEMP/licenses"
+
+echo "> Building base ruby26common image"
+docker build -t "ruby26common" - < "${DIR}/parent.Dockerfile"
+echo "> Building penghuima/buildpacks-ruby26-run:$TAG"
+docker build --build-arg "from_image=ruby26common" -t "penghuima/buildpacks-ruby26-run:$TAG" - < "${DIR}/run.Dockerfile"
+echo "> Building penghuima/buildpacks-ruby26-build:$TAG"
+docker build --build-arg "from_image=ruby26common" -t "penghuima/buildpacks-ruby26-build:$TAG" -f "${DIR}/build.Dockerfile" "${TEMP}"

--- a/builders/ruby26/stack/parent.Dockerfile
+++ b/builders/ruby26/stack/parent.Dockerfile
@@ -1,0 +1,51 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/gcp-runtimes/ubuntu_18_0_4
+
+ARG cnb_uid=1000
+ARG cnb_gid=1000
+ARG stack_id="openfunction.ruby26"
+
+# Required by python/runtime: libexpat1, libffi6, libmpdecc2.
+# Required by dotnet/runtime: libicu60
+# Required by go/runtime: tzdata (Go may panic without /usr/share/zoneinfo)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libexpat1 \
+  libffi6 \
+  libmpdec2 \
+  libicu60 \
+  libc++1-9 \
+  tzdata \
+  gcc libc6-dev make  zlib1g zlib1g-dev  openssl libssl-dev \
+  && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+LABEL io.buildpacks.stack.id=${stack_id}
+
+RUN groupadd cnb --gid ${cnb_gid} && \
+  useradd --uid ${cnb_uid} --gid ${cnb_gid} -m -s /bin/bash cnb
+
+# install ruby runtime
+RUN cd /tmp && mkdir ruby && cd ruby && curl  https://cache.ruby-lang.org/pub/ruby/2.6/ruby-2.6.6.tar.gz | tar xz \
+    && cd ruby-2.6.6 && ./configure && make && make install  \
+    && cd ext/zlib \
+    && ruby extconf.rb && sed -i 's?$(top_srcdir)?../..?g' Makefile  && make && make install \
+    && cd ../openssl \
+    && ruby extconf.rb && sed -i 's?$(top_srcdir)?../..?g' Makefile && make && make install \
+#    && gem install bundler -v 2.1.4 \
+    && cd ../../
+
+ENV CNB_USER_ID=${cnb_uid}
+ENV CNB_GROUP_ID=${cnb_gid}
+ENV CNB_STACK_ID=${stack_id}

--- a/builders/ruby26/stack/run.Dockerfile
+++ b/builders/ruby26/stack/run.Dockerfile
@@ -1,0 +1,19 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG from_image
+FROM ${from_image}
+
+ENV PORT 8080
+USER cnb


### PR DESCRIPTION
The function of Stack is to provide a basic operating environment, which contains two types of images:

- build, provides a running environment for the Build phase of Lifecycle

- run, to provide a running environment for business applications