### PR TITLE
Generate a builder

### DIFF
--- a/builders/BUILD.bazel
+++ b/builders/BUILD.bazel
@@ -68,5 +68,6 @@ package_group(
     name = "ruby_builders",
     packages = [
         "//builders/base",
+        "//builders/ruby26",
     ],
 )

--- a/builders/ruby26/BUILD.bazel
+++ b/builders/ruby26/BUILD.bazel
@@ -1,0 +1,22 @@
+load("//tools:defs.bzl", "builder")
+
+licenses(["notice"])
+
+builder(
+    name = "builder",
+    buildpacks = [
+        "//cmd/config/entrypoint:entrypoint.tgz",
+        "//cmd/utils/label:label.tgz",
+        ],
+    groups = {
+        "ruby": [
+            "//cmd/ruby/functions_framework:functions_framework.tgz",
+            "//cmd/ruby/bundle:bundle.tgz",
+        ],
+    },
+
+    image = "of/ruby26",
+    visibility = [
+            "//builders/ruby26/acceptance:__pkg__",
+        ],
+)

--- a/builders/ruby26/builder.toml
+++ b/builders/ruby26/builder.toml
@@ -1,0 +1,39 @@
+description = "Builder for the GCF Ruby 2.6 runtime"
+
+[[buildpacks]]
+  id = "google.ruby.functions-framework"
+  uri = "ruby/functions_framework.tgz"
+
+[[buildpacks]]
+  id = "google.ruby.bundle"
+  uri = "ruby/bundle.tgz"
+
+[[buildpacks]]
+  id = "google.config.entrypoint"
+  uri = "entrypoint.tgz"
+
+[[buildpacks]]
+  id = "google.utils.label"
+  uri = "label.tgz"
+
+[[order]]
+
+  [[order.group]]
+    id = "google.ruby.bundle"
+
+  [[order.group]]
+    id = "google.ruby.functions-framework"
+
+  [[buildpacks]]
+    id = "google.config.entrypoint"
+
+  [[order.group]]
+    id = "google.utils.label"
+
+[stack]
+  id = "openfunction.ruby26"
+  build-image = "openfunctiondev/buildpacks-ruby26-build:v1"
+  run-image = "openfunctiondev/buildpacks-ruby26-run:v1"
+
+[lifecycle]
+  version = "0.11.1"

--- a/cmd/config/entrypoint/BUILD.bazel
+++ b/cmd/config/entrypoint/BUILD.bazel
@@ -13,6 +13,7 @@ buildpack(
         "//builders:java_builders",
         "//builders:nodejs_builders",
         "//builders:python_builders",
+        "//builders:ruby_builders",
     ],
 )
 

--- a/cmd/config/entrypoint/buildpack.toml
+++ b/cmd/config/entrypoint/buildpack.toml
@@ -9,6 +9,9 @@ name = "Config - Entrypoint"
 id = "google"
 
 [[stacks]]
+id = "openfunction.ruby26"
+
+[[stacks]]
 id = "openfunction.go115"
 
 [[stacks]]

--- a/cmd/ruby/bundle/buildpack.toml
+++ b/cmd/ruby/bundle/buildpack.toml
@@ -6,6 +6,9 @@ version = "0.9.0"
 name = "Ruby - Bundle"
 
 [[stacks]]
+id = "openfunction.ruby26"
+
+[[stacks]]
 id = "google.ruby25"
 
 [[stacks]]

--- a/cmd/ruby/functions_framework/buildpack.toml
+++ b/cmd/ruby/functions_framework/buildpack.toml
@@ -6,7 +6,7 @@ version = "0.9.1"
 name = "Ruby - Functions Framework"
 
 [[stacks]]
-id = "google"
+id = "openfunction.ruby26"
 
 [[stacks]]
 id = "google.ruby26"

--- a/cmd/utils/label/buildpack.toml
+++ b/cmd/utils/label/buildpack.toml
@@ -58,3 +58,6 @@ id = "google.ruby26"
 
 [[stacks]]
 id = "google.ruby27"
+
+[[stacks]]
+id = "openfunction.ruby26"


### PR DESCRIPTION
After executing the command `bazel build //builders/ruby26:builder.image`, a builder image will be generated
the builder image `penghuima/ruby26`