### PR TITLE
Adjusting the form of the FUNC_GOPROXY env parameter

### DIFF
--- a/pkg/golang/golang.go
+++ b/pkg/golang/golang.go
@@ -16,6 +16,7 @@
 package golang
 
 import (
+	"fmt"
 	"github.com/GoogleCloudPlatform/buildpacks/pkg/env"
 	"os"
 	"path/filepath"
@@ -152,7 +153,7 @@ func ExecWithGoproxyFallback(ctx *gcp.Context, cmd []string, opts ...gcp.ExecOpt
 	if SupportsGoProxyFallback(ctx) {
 		goProxy := os.Getenv(env.GoProxy)
 		if goProxy != "" {
-			opts = append(opts, gcp.WithEnv(goProxy))
+			opts = append(opts, gcp.WithEnv(fmt.Sprintf("GOPROXY=%s", goProxy)))
 		}
 		return ctx.Exec(cmd, opts...)
 	}


### PR DESCRIPTION
Modified the form of passing **FUNC_GOPROXY**

from 
```shell
FUNC_GOPROXY="GOPROXY=https://***"
```
to
```shell
FUNC_GOPROXY="http://***"
```

Signed-off-by: laminar <fangtian@kubesphere.io>