### PR TITLE
Update the default version of functions-framework-go to v0.2.3

### DIFF
--- a/cmd/go/of_functions_framework/main.go
+++ b/cmd/go/of_functions_framework/main.go
@@ -41,7 +41,7 @@ const (
 
 var (
 	tmplV0                    = template.Must(template.New("main").Parse(mainTextTemplate))
-	functionsFrameworkVersion = "v0.2.1"
+	functionsFrameworkVersion = "v0.2.3"
 )
 
 type fnInfo struct {


### PR DESCRIPTION
Signed-off-by: laminar <fangtian@kubesphere.io>